### PR TITLE
Add logo into documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,5 @@ after_success:
   - julia -e 'cd(Pkg.dir("Microbiome")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
   # build docs
   - julia -e 'Pkg.add("Documenter")'
+  - julia -e 'cd(joinpath(Pkg.dir("Microbiome"), "docs/src")); mkdir("assets"); cd("assets"); run(pipeline(`curl https://codeload.github.com/BioJulia/assets/tar.gz/master`, `tar -xz --strip=2 assets-master/doc_assets`))'
   - julia -e 'cd(Pkg.dir("Microbiome")); include(joinpath("docs", "make.jl"))'


### PR DESCRIPTION
This addition to travis doc building steps means the biojulia logo will be included into the menu bar, this could also be changed to any other image you might want to add or use in the BioJulia/assets repo, which stores common images and resources for all package pages, to try and keep them all in sync.