### PR TITLE
Metadata for CommunityProfiles

### DIFF
--- a/src/Microbiome.jl
+++ b/src/Microbiome.jl
@@ -37,7 +37,8 @@ export CommunityProfile,
        profiletype,
        featuretotals,
        sampletotals,
-       commjoin
+       commjoin,
+       metadata
    
 # Abundances
 export present,

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -340,7 +340,7 @@ eg `DataFrame`.
 function metadata(cp::CommunityProfile)
     ss = samples(cp)
     cols = unique(reduce(hcat, collect.(keys.(metadata.(samples(cp))))))
-    return (merge((; sample=name(s)), 
+    return Tables.rowtable(merge((; sample=name(s)), 
                      NamedTuple(c => get(s, c, missing) for c in cols)
                     ) for s in ss)
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -323,3 +323,24 @@ function prevalence_filter(comm::AbstractAbundanceTable; minabundance=0.0, minpr
     comm = comm[vec(prevalence(comm, minabundance) .>= minprevalence), :]
     return renorm ? relativeabundance(comm) : comm
 end
+
+
+## Metadata
+
+"""
+    metadata(cp::CommunityProfile)
+
+Returns iterator of `NamedTuple` per sample, where keys are `:sample`
+and each metadata key found in `cp`.
+Samples without given metadata are filled with `missing`.
+
+Returned values can be passed to any Tables.rowtable - compliant type,
+eg `DataFrame`.
+"""
+function metadata(cp::CommunityProfile)
+    ss = samples(cp)
+    cols = unique(reduce(hcat, collect.(keys.(metadata.(samples(cp))))))
+    return (merge((; sample=name(s)), 
+                     NamedTuple(c => get(s, c, missing) for c in cols)
+                    ) for s in ss)
+end

--- a/src/samples_features.jl
+++ b/src/samples_features.jl
@@ -75,6 +75,7 @@ end
 
 Base.keys(as::AbstractSample) = keys(metadata(as))
 Base.haskey(as::AbstractSample, key::Symbol) = in(key, keys(as))
+Base.get(as::AbstractSample, key::Symbol, default) = get(metadata(as), key, default)
 
 """
     MicrobiomeSample(name::String, metadata::Dictionary{Symbol, T}) <: AbstractSample

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,6 +145,19 @@ end
         @test size(prevalence_filter(filtertest, minabundance=2, minprevalence=0.4)) == (2,3)
         @test all(<=(1.0), abundances(prevalence_filter(filtertest, renorm=true)))
         @test all(x-> isapprox(x, 1.0, atol=1e-8), sum(abundances(prevalence_filter(filtertest, renorm=true)), dims=1))
+
+        s1 = MicrobiomeSample("sample1", Dictionary(Dict(:age=> 37, :name=>"kevin", :something=>1.0)))
+        s2 = MicrobiomeSample("sample2", Dictionary(Dict(:age=> 37, :name=>"kevin", :something_else=>2.0)))
+
+        md1, md2 = metadata(CommunityProfile(sparse([1 1; 2 2; 3 3]), [Taxon(string(i)) for i in 1:3], [s1, s2]))
+        
+        @test all(row-> row[:age] == 37, [md1, md2])
+        @test all(row-> row[:name] == "kevin", [md1, md2])
+        @test md1[:something] == 1.0
+        @test ismissing(md2[:something])
+        @test md2[:something_else] == 2.0
+        @test ismissing(md1[:something_else])
+
     end
     
     @testset "Indexing and Tables integration" begin


### PR DESCRIPTION
# Better metadata handling for `CommunityProfiles`

Right now, metadata is bound to individual samples, but it would be good to bulk import / export / set it for `CommunityProfile` types. Should address #63 and #64. I also added a `get()` method for `AbstractSample`s.

## Types of changes

This PR implements the following changes:

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [ ] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [ ] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [ ] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [ ] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
