### PR TITLE
add constructor with dense matrix

### DIFF
--- a/src/Microbiome.jl
+++ b/src/Microbiome.jl
@@ -71,6 +71,7 @@ using Distances
 using MultivariateStats
 
 import Dictionaries: set!, unset!, insert!, delete!
+import Base: ==
 
 include("ecobase.jl")
 include("samples_features.jl")

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -70,7 +70,19 @@ function CommunityProfile{T, F, S}(tab::SparseMatrixCSC{<:T},
                                    samples::AbstractVector{S}) where {T, F, S}
     return CommunityProfile(tab, features, samples)
 end
+
+function CommunityProfile(tab::AbstractMatrix,
+                          features::AbstractVector{<:AbstractFeature},
+                          samples::AbstractVector{<:AbstractSample})
+    return CommunityProfile(sparse(tab), features, samples)
+end
 ## -- Convienience functions -- ##
+
+function ==(p1::CommunityProfile, p2::CommunityProfile)
+    return abundances(p1) == abundances(p2) && 
+           samples(p1)    == samples(p2) &&
+           features(p1)   == features(p2)
+end
 
 """
     features(at::AbstractAbundanceTable)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,14 +85,23 @@ end
     push!(txs, Taxon("taxon10", missing))
     
     mat = spzeros(10,5)
-    for i in 1:5; mat[i,i] = 1.; end
-    for i in 1:5; mat[i+5,i] = 0.6; end
+    dmat = zeros(10,5)
+    for i in 1:5; 
+        mat[i,i] = 1.
+        dmat[i,i] = 1.
+    end
+    for i in 1:5
+        mat[i+5,i] = 0.6
+        dmat[i+5,i] = 0.6
+    end
 
     comm = CommunityProfile(mat, txs, mss)
-    
+
     @testset "Profile operations" begin
         @test repr(comm) == "CommunityProfile{Float64, Taxon, MicrobiomeSample} with 10 features in 5 samples\n\nFeature names:\ntaxon1, taxon2, taxon3...taxon9, taxon10\n\nSample names:\nsample1, sample2, sample3, sample4, sample5\n\n"
         @test CommunityProfile{Float64, Taxon, MicrobiomeSample}(mat, txs, mss) isa CommunityProfile
+        @test comm == CommunityProfile(dmat, txs, mss)
+        
         @test nsamples(comm) == 5
         @test nfeatures(comm) == 10
         @test size(comm) == (10, 5)


### PR DESCRIPTION
It's annoying to always have `SparseArrays` around - this makes it possible to construct a CommunityProfile with a dense matrix too.