### PR TITLE
Add dictionary methods to CommunityProfiles

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -493,4 +493,4 @@ end
 
 Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(samples(commp, sample)))
 Base.haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol) = in(key, keys(samples(commp, sample)))
-Base.get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default) = get(metadata(samples(commp, sample), key, default))
+Base.get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default) = get(metadata(samples(commp, sample)), key, default)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -463,3 +463,34 @@ function add_metadata!(commp::CommunityProfile, samplecol::Symbol, md; overwrite
     return nothing
 end
 
+function set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
+    sample = samples(commp, sample)
+    prop in _restricted_fields(sample) && error("Cannot set! $prop for $(typeof(sample)).")
+    set!(sample.metadata, prop, val)
+    return sample
+end
+
+function unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
+    sample = samples(commp, sample)
+    prop in _restricted_fields(sample) && error("Cannot unset! $prop for $(typeof(sample)).")
+    unset!(sample.metadata, prop)
+    return sample
+end
+
+function insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
+    sample = samples(commp, sample)
+    prop in _restricted_fields(sample) && error("Cannot insert! $prop for $(typeof(sample)).")
+    insert!(sample.metadata, prop, val)
+    return sample
+end
+
+function delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
+    sample = samples(commp, sample)
+    prop in _restricted_fields(sample) && error("Cannot delete! $prop for $(typeof(sample)).")
+    delete!(sample.metadata, prop)
+    return sample
+end
+
+Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(samples(commp, sample)))
+Base.haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol) = in(key, keys(samples(commp, sample)))
+Base.get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default) = get(metadata(samples(commp, sample), key, default))

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -354,28 +354,28 @@ end
 ## Metadata
 
 """
-    metadata(cp::CommunityProfile)
+    metadata(commp::CommunityProfile)
 
 Returns iterator of `NamedTuple` per sample, where keys are `:sample`
-and each metadata key found in `cp`.
+and each metadata key found in `commp`.
 Samples without given metadata are filled with `missing`.
 
 Returned values can be passed to any Tables.rowtable - compliant type,
 eg `DataFrame`.
 ```
 """
-function metadata(cp::CommunityProfile)
-    ss = samples(cp)
-    cols = unique(reduce(vcat, collect.(keys.(metadata.(samples(cp))))))
+function metadata(commp::CommunityProfile)
+    ss = samples(commp)
+    cols = unique(reduce(vcat, collect.(keys.(metadata.(samples(commp))))))
     return Tables.rowtable(merge((; sample=name(s)), 
                      NamedTuple(c => get(s, c, missing) for c in cols)
                     ) for s in ss)
 end
 
 """
-    add_metadata!(cp::CommunityProfile, samplename::AbstractString, md::Union{AbstractDict,NamedTuple}; overwrite=false)
+    add_metadata!(commp::CommunityProfile, samplename::AbstractString, md::Union{AbstractDict,NamedTuple}; overwrite=false)
 
-Add metadata (in the form of an `AbstractDict` or `NamedTuple`) to the `MicrobiomeSample` in `cp` with name `samplename`.
+Add metadata (in the form of an `AbstractDict` or `NamedTuple`) to the `MicrobiomeSample` in `commp` with name `samplename`.
 For `AbstractDict`s, all keys must be `Symbol`s. 
 
 The function will fail if any of the keys in `md` already exist in the `MicrobiomeSample`,
@@ -399,8 +399,8 @@ julia> metadata(comm)
  (sample = "sample2", subjectname = missing, age = missing)
  (sample = "sample3", subjectname = missing, age = missing)
 """
-function add_metadata!(cp::CommunityProfile, samplename::AbstractString, md::Union{AbstractDict,NamedTuple}; overwrite=false)
-    s = samples(cp, samplename)
+function add_metadata!(commp::CommunityProfile, samplename::AbstractString, md::Union{AbstractDict,NamedTuple}; overwrite=false)
+    s = samples(commp, samplename)
     if !overwrite
         length(keys(md) ∩ keys(metadata(s))) == 0 || throw(IndexError("Adding this metadata would overwrite existing values. Use `overwrite=true` to proceed anyway"))
     end
@@ -413,10 +413,10 @@ function add_metadata!(cp::CommunityProfile, samplename::AbstractString, md::Uni
 end
 
 """
-    add_metadata!(cp::CommunityProfile, samplecol::Symbol, md; overwrite=false)
+    add_metadata!(commp::CommunityProfile, samplecol::Symbol, md; overwrite=false)
 
 Add metadata (in the form of a `Tables.jl` table) a `CommunityProfile`.
-One column (`samplecol`) should contain sample names that exist in `cp`,
+One column (`samplecol`) should contain sample names that exist in `commp`,
 and other columns should contain metadata that will be added to the metadata of each sample.
 
 The function will fail if any of the column names in `md` already exist as metadata in any of the `MicrobiomeSample`s,
@@ -446,11 +446,11 @@ julia> metadata(comm)
  (sample = "sample3", something = 42, newthing = "fuz")
  ```
 """
-function add_metadata!(cp::CommunityProfile, samplecol::Symbol, md; overwrite = false)
+function add_metadata!(commp::CommunityProfile, samplecol::Symbol, md; overwrite = false)
     Tables.istable(md) || throw(ArgumentError("Metadata must be a Tables.table"))
     for row in Tables.rows(md)
-        row[samplecol] in samplenames(cp) || throw(IndexError("Sample '$(row[samplecol])' not found in CommunityProfile"))
-        sample = samples(cp, row[samplecol])
+        row[samplecol] in samplenames(commp) || throw(IndexError("Sample '$(row[samplecol])' not found in CommunityProfile"))
+        sample = samples(commp, row[samplecol])
         if !overwrite
             any(k-> haskey(sample, k), Tables.columnnames(row)) && throw(IndexError("Adding this metadata would overwrite existing values. Use `overwrite=true` to proceed anyway"))
         end
@@ -458,7 +458,8 @@ function add_metadata!(cp::CommunityProfile, samplecol::Symbol, md; overwrite = 
 
     for row in Tables.rows(md)
         rowmd = Dict(col=> row[col] for col in Tables.columnnames(row) if col != samplecol)
-        add_metadata!(cp, row[samplecol], rowmd; overwrite)
+        add_metadata!(commp, row[samplecol], rowmd; overwrite)
     end
     return nothing
 end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,12 +168,19 @@ end
             @test_throws Dictionaries.IndexError insert!(c4, "sample1", :something, 3.0)
             @test_throws Dictionaries.IndexError delete!(c4, "sample1", :something_else)
 
-            @test set!(c4, "sample1", :something, 3.0) isa MicrobiomeSample
-            @test first(metadata(c4))[:something] == 3
+            @test delete!(c4, "sample1", :something) isa MicrobiomeSample
+            @test !haskey(c4, "sample1", :something)
+            @test get(c4, "sample1", :something_else, 42) == 42
+            @test insert!(c4, "sample1", :something, 3.0) isa MicrobiomeSample
+            @test get(c4, "sample1", :something, 42) == 3.0
+            set!(c4, "sample1", :something, 1.0)
+            @test first(metadata(c4))[:something] == 1.0
             @test haskey(c4, "sample1", :something)
             @test unset!(c4, "sample1", :something) isa MicrobiomeSample
             @test !haskey(c4, "sample1", :something)
             set!(c4, "sample1", :something, 1.0)
+
+            @test collect(keys(c4, "sample1")) == [:age, :name, :something]
         end
 
         @testset "Whole community" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,12 +155,30 @@ end
         @test size(prevalence_filter(filtertest, minabundance=2, minprevalence=0.4)) == (2,3)
         @test all(<=(1.0), abundances(prevalence_filter(filtertest, renorm=true)))
         @test all(x-> isapprox(x, 1.0, atol=1e-8), sum(abundances(prevalence_filter(filtertest, renorm=true)), dims=1))
+    end
 
+    @testset "Profile Metadata" begin
         s1 = MicrobiomeSample("sample1", Dictionary(Dict(:age=> 37, :name=>"kevin", :something=>1.0)))
         s2 = MicrobiomeSample("sample2", Dictionary(Dict(:age=> 37, :name=>"kevin", :something_else=>2.0, :still_other=>"boo")))
 
-        let c4 = CommunityProfile(sparse([1 1; 2 2; 3 3]), [Taxon(string(i)) for i in 1:3], [s1, s2])
+        @testset "Single sample" begin
+            c4 = CommunityProfile(sparse([1 1; 2 2; 3 3]), [Taxon(string(i)) for i in 1:3], [s1, s2])
             md1, md2 = metadata(c4)
+
+            @test_throws Dictionaries.IndexError insert!(c4, "sample1", :something, 3.0)
+            @test_throws Dictionaries.IndexError delete!(c4, "sample1", :something_else)
+
+            @test set!(c4, "sample1", :something, 3.0) isa MicrobiomeSample
+            @test first(metadata(c4))[:something] == 3
+            @test haskey(c4, "sample1", :something)
+            @test unset!(c4, "sample1", :something) isa MicrobiomeSample
+            @test !haskey(c4, "sample1", :something)
+            set!(c4, "sample1", :something, 1.0)
+        end
+
+        @testset "Whole community" begin
+            c5 = CommunityProfile(sparse([1 1; 2 2; 3 3]), [Taxon(string(i)) for i in 1:3], [s1, s2])
+            md1, md2 = metadata(c5)
             
             @test all(row-> row[:age] == 37, [md1, md2])
             @test all(row-> row[:name] == "kevin", [md1, md2])
@@ -169,23 +187,22 @@ end
             @test md2[:something_else] == 2.0
             @test ismissing(md1[:something_else])
 
-            @test_throws IndexError add_metadata!(c4, "sample1", Dict(:something=>3.0))
-            add_metadata!(c4, "sample1", Dict(:something=>3.0), overwrite=true)
-            @test first(metadata(c4))[:something] == 3
+            @test_throws IndexError add_metadata!(c5, "sample1", Dict(:something=>3.0))
+            add_metadata!(c5, "sample1", Dict(:something=>3.0), overwrite=true)
+            @test first(metadata(c5))[:something] == 3
             
-            @test_throws IndexError add_metadata!(c4, "sample1", (; something=4.0))
-            add_metadata!(c4, "sample1", (; something=4.0), overwrite=true)
-            @test first(metadata(c4))[:something] == 4
+            @test_throws IndexError add_metadata!(c5, "sample1", (; something=4.0))
+            add_metadata!(c5, "sample1", (; something=4.0), overwrite=true)
+            @test first(metadata(c5))[:something] == 4
 
             tbl = [(sample="sample1", something=5,  newthing="bar"),
                    (sample="sample2", something=10, newthing="baz"),
                    (sample="sample3", something=42, newthing="fuz")]
-            @test_throws IndexError add_metadata!(c4, :sample, tbl, overwrite=true) # for sample that doesn't exist
-            @test_throws IndexError add_metadata!(c4, :sample, tbl[1:2])            # for metadata that already exists
-            add_metadata!(c4, :sample, tbl[1:2]; overwrite = true)
-            @test first(metadata(c4))[:something] == 5
-            @test first(metadata(c4))[:newthing] == "bar"
-
+            @test_throws IndexError add_metadata!(c5, :sample, tbl, overwrite=true) # for sample that doesn't exist
+            @test_throws IndexError add_metadata!(c5, :sample, tbl[1:2])            # for metadata that already exists
+            add_metadata!(c5, :sample, tbl[1:2]; overwrite = true)
+            @test first(metadata(c5))[:something] == 5
+            @test first(metadata(c5))[:newthing] == "bar"
         end
     end
     


### PR DESCRIPTION
Closes #65 

As I was writing this, it occurred to me that the `add_metadata!()` method I added in #63 for adding to a single sample doesn't really make sense, we should use `insert!` and `set!` for that, as done here. 
