### PR TITLE
Add generic filter for CommunityProfiles

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -387,9 +387,11 @@ julia> features(cladefilter(comm, :genus; keepempty = true))
 """
 function cladefilter(comm::AbstractAbundanceTable, cl::Symbol; keepempty=false)
     in(cl, keys(_clades)) ||  error("Invalid clade $cl, must be one of $(keys(_clades))")
-    ridx = keepempty ? findall(c-> ismissing(c) || c == cl, clades(comm)) : findall(c-> !ismissing(c) && c == cl, clades(comm))
-    isempty(ridx) && error("No rows with clade $cl found, can't return empty profile")
-    return copy(comm[ridx, :])
+    if keepempty
+        return filter(f-> !hasclade(f) || clade(f) == cl, comm)
+    else
+        return filter(f-> hasclade(f) && clade(f) == cl, comm)
+    end
 end
 
 function cladefilter(comm::AbstractAbundanceTable, clade::Int; keepempty=false)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -541,3 +541,32 @@ end
 Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(samples(commp, sample)))
 Base.haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol) = in(key, keys(samples(commp, sample)))
 Base.get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default) = get(metadata(samples(commp, sample)), key, default)
+
+
+"""
+    filter(f, comm::CommunityProfile)
+
+Apply `f` to the features of `comm`,
+and return a copy where `f(feature)` is `true`.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> features(comm)
+3-element Vector{GeneFunction}:
+ GeneFunction("gene1", Taxon("tax1", :species))
+ GeneFunction("gene1", Taxon("tax2", :genus))
+ GeneFunction("gene2", missing)
+
+julia> features(filter(hastaxon, comm))
+2-element Vector{GeneFunction}:
+ GeneFunction("gene1", Taxon("tax1", :species))
+ GeneFunction("gene1", Taxon("tax2", :genus))
+```
+"""
+function Base.filter(f::Function, commp::CommunityProfile)
+    ridx = findall(f, features(commp))
+    isempty(ridx) && error("Can't return empty profile")
+    return copy(commp[ridx, :])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,6 +124,8 @@ end
         @test_throws ErrorException cladefilter(comm, 10)
         @test_throws ErrorException cladefilter(cladefilter(comm, :species), :genus) # will be empty
 
+        @test filter(f-> hasclade(f) && clade(f) == :species, comm) == cladefilter(comm, :species)
+
         @test present(0.1)
         @test !present(0.1, 0.2)
         @test_throws DomainError present(-0.1)


### PR DESCRIPTION
Closes #68, thought taking a slightly different tack. I just added a generic `filter()` method, so one can for example get unstratified gene functions by just doing `filter(!hastaxon, comm)` 