### PR TITLE
Adding docstrings to CP methods

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -516,6 +516,7 @@ end
     set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
 
 Update or insert a value `val` to the `sample` in the CommunityProfile `commp` using a Symbol `prop`. 
+If you want an error to be thrown if the value does not exist, use [`insert!`](@ref).
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -537,7 +538,8 @@ end
 """
     unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
 
-Delete a `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
+Delete a `sample` from CommunityProfile `commp` using the Symbol `prop`. 
+If you want an error to be thrown if the value does not exist, use [`delete!`](@ref).
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -559,7 +561,10 @@ end
 """
     insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
 
-Insert a value `val` to the `sample` in a CommunityProfile `commp` using a Symbol `prop`.
+Insert a value `val` to the `sample` in a CommunityProfile `commp` using a Symbol `prop`, 
+and it will throw an error if `prop` exists. 
+If you don't want an error to be thrown if the value does not exist, use [`set!`](@ref).
+
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -582,6 +587,7 @@ end
     delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
 
 Delete a `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
+If you don't want an error to be thrown if the value does not exist, use [`unset!`](@ref).
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -603,8 +609,9 @@ end
 """
     keys(commp::CommunityProfile, sample::AbstractString)
 
-Return an iterator over all keys of samples in a CommunityProfile. collect(keys(a)) returns an array of keys. When the keys are stored internally in a hash table, as is
-the case for `Dict`, the order in which they are returned may vary. But `keys(a)` and `values(a)` both iterate a and return the elements in the same order.
+Return an iterator over all keys of samples in a CommunityProfile. collect(keys(a)) returns an array of keys. 
+When the keys are stored internally in a hash table, as is the case for `Dict`, the order in which they are returned may vary. 
+But `keys(a)` and `values(a)` both iterate a and return the elements in the same order.
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -616,14 +623,15 @@ julia> collect(keys(comm, "sample1"))
 2-element Vector{Symbol}:
  :subjectname
  :age
- ```
+```
 """
 Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(samples(commp, sample)))
 
 """
     haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol)
 
-Determine whether a `sample` in a CommunityProfile has a mapping for a given `key`. Use !haskey to determine whether a `sample` in a CommunityProfile doesn't have a mapping for a given `key`
+Determine whether a `sample` in a CommunityProfile has a mapping for a given `key`. 
+Use !haskey to determine whether a `sample` in a CommunityProfile doesn't have a mapping for a given `key`
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -515,8 +515,8 @@ end
 """
     set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
 
-Update or insert a value `val` to the `sample` in the CommunityProfile `commp` using a Symbol `prop`. 
-If you want an error to be thrown if the value does not exist, use [`insert!`](@ref).
+Update or insert a value `val` to the metadata of `sample` in the CommunityProfile `commp` using a Symbol `prop`. 
+If you want an error to be thrown if the value already exists, use [`insert!`](@ref).
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -538,7 +538,7 @@ end
 """
     unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
 
-Delete a `sample` from CommunityProfile `commp` using the Symbol `prop`. 
+Delete a metadata entry in `sample` from CommunityProfile `commp` using the Symbol `prop`. 
 If you want an error to be thrown if the value does not exist, use [`delete!`](@ref).
 
 Examples
@@ -561,7 +561,7 @@ end
 """
     insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
 
-Insert a value `val` to the `sample` in a CommunityProfile `commp` using a Symbol `prop`, 
+Insert a value `val` to the metadata of `sample` in a CommunityProfile `commp` using a Symbol `prop`, 
 and it will throw an error if `prop` exists. 
 If you don't want an error to be thrown if the value does not exist, use [`set!`](@ref).
 
@@ -586,7 +586,7 @@ end
 """
     delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
 
-Delete a `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
+Delete a metadata entry in `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
 If you don't want an error to be thrown if the value does not exist, use [`unset!`](@ref).
 
 Examples
@@ -609,9 +609,8 @@ end
 """
     keys(commp::CommunityProfile, sample::AbstractString)
 
-Return an iterator over all keys of samples in a CommunityProfile. collect(keys(a)) returns an array of keys. 
-When the keys are stored internally in a hash table, as is the case for `Dict`, the order in which they are returned may vary. 
-But `keys(a)` and `values(a)` both iterate a and return the elements in the same order.
+Return an iterator over all keys of the metadata attached to `sample` in a CommunityProfile `commp`. 
+`collect(keys(commp, sample))` returns an array of keys. 
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -630,8 +629,8 @@ Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(sampl
 """
     haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol)
 
-Determine whether a `sample` in a CommunityProfile has a mapping for a given `key`. 
-Use !haskey to determine whether a `sample` in a CommunityProfile doesn't have a mapping for a given `key`
+Determine whether the metadata of `sample` in a CommunityProfile `commp` has a mapping for a given `key`. 
+Use `!haskey` to determine whether a `sample` in a CommunityProfile doesn't have a mapping for a given `key`
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -653,7 +652,7 @@ Base.haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol) = in(k
 """
     get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default)
 
-Return the value stored for the given `key`, or the given default value if no mapping for the key is present.
+Return the value of the metadata in a `sample` stored for the given `key`, or the given `default` value if no mapping for the key is present.
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -512,6 +512,21 @@ function add_metadata!(commp::CommunityProfile, samplecol::Symbol, md; overwrite
     return nothing
 end
 
+"""
+    set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
+
+Update or insert a value `val` to the `sample` in the CommunityProfile `commp` using a Symbol `prop`. 
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> set!(comm, "sample1", :something, 1.0)
+
+julia> first(metadata(comm))[:something]
+1.0
+ ```
+"""
 function set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
     sample = samples(commp, sample)
     prop in _restricted_fields(sample) && error("Cannot set! $prop for $(typeof(sample)).")
@@ -519,6 +534,21 @@ function set!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val
     return sample
 end
 
+"""
+    unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
+
+Delete a `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> unset!(comm, "sample1", :something) 
+
+julia> !haskey(comm, "sample1", :something)
+true
+ ```
+"""
 function unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
     sample = samples(commp, sample)
     prop in _restricted_fields(sample) && error("Cannot unset! $prop for $(typeof(sample)).")
@@ -526,6 +556,21 @@ function unset!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
     return sample
 end
 
+"""
+    insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
+
+Insert a value `val` to the `sample` in a CommunityProfile `commp` using a Symbol `prop`.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> insert!(comm, "sample1", :something, 3.0) 
+
+julia> get(comm, "sample1", :something, 3.0)
+3.0
+ ```
+"""
 function insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, val)
     sample = samples(commp, sample)
     prop in _restricted_fields(sample) && error("Cannot insert! $prop for $(typeof(sample)).")
@@ -533,6 +578,21 @@ function insert!(commp::CommunityProfile, sample::AbstractString, prop::Symbol, 
     return sample
 end
 
+"""
+    delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
+
+Delete a `sample` from CommunityProfile `commp` using the Symbol `prop` if it exists, or throw an error otherwise.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> delete!(comm, "sample1", :something) 
+
+julia> !haskey(comm, "sample1", :something)
+true
+ ```
+"""
 function delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
     sample = samples(commp, sample)
     prop in _restricted_fields(sample) && error("Cannot delete! $prop for $(typeof(sample)).")
@@ -540,8 +600,66 @@ function delete!(commp::CommunityProfile, sample::AbstractString, prop::Symbol)
     return sample
 end
 
+"""
+    keys(commp::CommunityProfile, sample::AbstractString)
+
+Return an iterator over all keys of samples in a CommunityProfile. collect(keys(a)) returns an array of keys. When the keys are stored internally in a hash table, as is
+the case for `Dict`, the order in which they are returned may vary. But `keys(a)` and `values(a)` both iterate a and return the elements in the same order.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> add_metadata!(comm, "sample1", Dict(:subjectname=>"kevin", :age=>37))
+
+julia> collect(keys(comm, "sample1"))
+2-element Vector{Symbol}:
+ :subjectname
+ :age
+ ```
+"""
 Base.keys(commp::CommunityProfile, sample::AbstractString) = keys(metadata(samples(commp, sample)))
+
+"""
+    haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol)
+
+Determine whether a `sample` in a CommunityProfile has a mapping for a given `key`. Use !haskey to determine whether a `sample` in a CommunityProfile doesn't have a mapping for a given `key`
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> set!(comm, "sample1", :something, 1.0)
+
+julia> haskey(comm, "sample1", :something)
+true
+
+julia> delete!(comm, "sample1", :something) 
+
+julia> !haskey(comm, "sample1", :something)
+true
+ ```
+"""
 Base.haskey(commp::CommunityProfile, sample::AbstractString, key::Symbol) = in(key, keys(samples(commp, sample)))
+
+"""
+    get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default)
+
+Return the value stored for the given `key`, or the given default value if no mapping for the key is present.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> get(comm, "sample1", :something, 42)
+42 
+
+julia> insert!(comm, "sample1", :something, 3.0) 
+
+julia> get(comm, "sample1", :something, 42)
+3.0
+ ```
+"""
 Base.get(commp::CommunityProfile, sample::AbstractString, key::Symbol, default) = get(metadata(samples(commp, sample)), key, default)
 
 

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -563,7 +563,7 @@ end
 
 Insert a value `val` to the metadata of `sample` in a CommunityProfile `commp` using a Symbol `prop`, 
 and it will throw an error if `prop` exists. 
-If you don't want an error to be thrown if the value does not exist, use [`set!`](@ref).
+If you don't want an error to be thrown if the value exists, use [`set!`](@ref).
 
 
 Examples

--- a/src/samples_features.jl
+++ b/src/samples_features.jl
@@ -49,32 +49,157 @@ function Base.setproperty!(as::AbstractSample, prop::Symbol, val)
     return as
 end
 
+"""
+    set!(as::AbstractSample, prop::Symbol, val)
+
+Update or insert a value `val` to the metadata of sample `as` using a Symbol `prop`. 
+If you want an error to be thrown if the value already exists, use [`insert!`](@ref).
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> set!(ms, :thing1, "metadata1")
+
+julia> ms.thing1
+"metadata1"
+```
+"""
 function set!(as::AbstractSample, prop::Symbol, val)
     prop in _restricted_fields(as) && error("Cannot set! $prop for $(typeof(as)).")
     set!(as.metadata, prop, val)
     return as
 end
 
+"""
+    unset!(as::AbstractSample, prop::Symbol)
+
+Delete a metadata entry of sample `as` using the Symbol `prop`. 
+If you want an error to be thrown if the value does not exist, use [`delete!`](@ref).
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> unset!(ms, :thing1)
+
+julia> !haskey(ms, :thing1)
+true
+```
+"""
 function unset!(as::AbstractSample, prop::Symbol)
     prop in _restricted_fields(as) && error("Cannot unset! $prop for $(typeof(as)).")
     unset!(as.metadata, prop)
     return as
 end
 
+"""
+    insert!(as::AbstractSample, prop::Symbol, val)
+
+Insert a value `val` to the metadata of sample `as` using a Symbol `prop`, 
+and it will throw an error if `prop` exists. 
+If you don't want an error to be thrown if the value does not exist, use [`set!`](@ref).
+
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> insert!(ms, :thing, "metadata")
+
+julia> ms.thing
+"metadata"
+```
+"""
 function insert!(as::AbstractSample, prop::Symbol, val)
     prop in _restricted_fields(as) && error("Cannot insert! $prop for $(typeof(as)).")
     insert!(as.metadata, prop, val)
     return as
 end
 
+"""
+    delete!(as::AbstractSample, prop::Symbol)
+
+Delete a metadata entry of sample `as` using the Symbol `prop` if it exists, or throw an error otherwise.
+If you don't want an error to be thrown if the value does not exist, use [`unset!`](@ref).
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> delete!(ms, :thing) 
+
+julia> !haskey(ms, :thing)
+true
+ ```
+"""
 function delete!(as::AbstractSample, prop::Symbol)
     prop in _restricted_fields(as) && error("Cannot delete! $prop for $(typeof(as)).")
     delete!(as.metadata, prop)
     return as
 end
 
+"""
+    keys(as::AbstractSample)
+
+Return an iterator over all keys of the metadata attached to sample `as`. 
+`collect(keys(as))` returns an array of keys. 
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> ms = MicrobiomeSample("sample1", Dictionary([:thing1, :thing2], ["metadata1", "metadata2"]))
+
+julia> collect(keys(ms))
+2-element Vector{Symbol}:
+ :thing1
+ :thing2
+```
+"""
 Base.keys(as::AbstractSample) = keys(metadata(as))
+
+"""
+    haskey(as::AbstractSample, key::Symbol)
+
+Determine whether the metadata of sample `as` has a mapping for a given `key`. 
+Use `!haskey` to determine whether a sample `as` in a CommunityProfile doesn't have a mapping for a given `key`
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> set!(ms, :thing1, "metadata1")
+
+julia> haskey(ms, :thing1)
+true
+
+julia> delete!(ms, :thing1, "metadata1")
+
+julia> !haskey(ms, :thing1)
+true
+```
+"""
 Base.haskey(as::AbstractSample, key::Symbol) = in(key, keys(as))
+
+"""
+    get(as::AbstractSample, key::Symbol, default)
+
+Return the value of the metadata in the sample `as` stored for the given `key`, or the given `default` value if no mapping for the key is present.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest
+julia> get(ms, :thing1, 42)
+42 
+
+julia> insert!(ms, :thing1, 3.0) 
+
+julia> get(ms, :thing1, 42)
+3.0
+```
+"""
 Base.get(as::AbstractSample, key::Symbol, default) = get(metadata(as), key, default)
 
 """

--- a/src/samples_features.jl
+++ b/src/samples_features.jl
@@ -98,7 +98,7 @@ end
 
 Insert a value `val` to the metadata of sample `as` using a Symbol `prop`, 
 and it will throw an error if `prop` exists. 
-If you don't want an error to be thrown if the value does not exist, use [`set!`](@ref).
+If you don't want an error to be thrown if the value exists, use [`set!`](@ref).
 
 
 Examples


### PR DESCRIPTION
# Adding docstrings to CP methods

> _This template is rather extensive. Fill out all that you can, if are a new contributor or you're unsure about any section, leave it unchanged and a reviewer will help you_ :smile:. _This template is simply a tool to help everyone remember the BioJulia guidelines, if you feel anything in this template is not relevant, simply delete it._

## Types of changes

This PR implements the following changes:
_(Please tick any or all of the following that are applicable)_

* [x] :sparkles: New feature (A non-breaking change which adds functionality).
* [ ] :bug: Bug fix (A non-breaking change, which fixes an issue).
* [ ] :boom: Breaking change (fix or feature that would cause existing functionality to change).

## :ballot_box_with_check: Checklist

- [x] :art: The changes implemented is consistent with the [julia style guide](https://docs.julialang.org/en/stable/manual/style-guide/).
- [x] :blue_book: I have updated and added relevant docstrings, in a manner consistent with the [documentation styleguide](https://docs.julialang.org/en/stable/manual/documentation/).
- [ ] :blue_book: I have added or updated relevant user and developer manuals/documentation in `docs/src/`.
- [ ] :ok: There are unit tests that cover the code changes I have made.
- [x] :ok: The unit tests cover my code changes AND they pass.
- [ ] :pencil: I have added an entry to the `[UNRELEASED]` section of the manually curated `CHANGELOG.md` file for this repository.
- [x] :ok: All changes should be compatible with the latest stable version of Julia.
- [ ] :thought_balloon: I have commented liberally for any complex pieces of internal code.
