### PR TITLE
GeneFunction equality

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -146,6 +146,12 @@ function Base.getindex(at::CommunityProfile{<:Real, <:GeneFunction, <:AbstractSa
     _index_profile(at, idx, (rowind, colind))
 end
 
+function Base.getindex(at::CommunityProfile{<:Real, <:GeneFunction, <:AbstractSample}, rowind::AbstractVector{<:AbstractString}, colind) 
+    rows = findall(fn-> any(==(fn), rowind), featurenames(at))
+    idx = at.aa[rows, colind]
+
+    _index_profile(at, idx, (rowind, colind))
+end
 
 
 ## -- EcoBase Translations -- ##

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -114,9 +114,7 @@ Base.copy(at::AbstractAbundanceTable) = typeof(at)(copy(abundances(at)), copy(fe
 
 # -- Indexing -- #
 
-function Base.getindex(at::CommunityProfile, inds...)
-    idx = at.aa[inds...]
-    
+function _index_profile(at, idx, inds)
     # single value - return that value
     ndims(idx) == 0 && return idx 
     # another table - return a new CommunityProfile with that table
@@ -132,6 +130,20 @@ function Base.getindex(at::CommunityProfile, inds...)
             return at[inds[1], [inds[2]]]
         end
     end
+end
+
+function Base.getindex(at::CommunityProfile, inds...)
+    idx = at.aa[inds...]
+    
+    _index_profile(at, idx, inds)
+end
+
+## Special lookup for gene function comm profiles
+function Base.getindex(at::CommunityProfile{<:Real, <:GeneFunction, <:AbstractSample}, rowind::AbstractString, colind) 
+    rows = findall(==(rowind), featurenames(at))
+    idx = at.aa[rows, colind]
+
+    _index_profile(at, idx, (rowind, colind))
 end
 
 

--- a/src/samples_features.jl
+++ b/src/samples_features.jl
@@ -386,3 +386,15 @@ clade(gf::GeneFunction) = clade(taxon(gf))
 Pretty self-explanatory.
 """
 hasclade(gf::GeneFunction) = hastaxon(gf) && !ismissing(clade(gf))
+
+
+# override equality for GeneFunction
+function Base.:(==)(gf1::GeneFunction, gf2::GeneFunction)
+    if all(!hastaxon, (gf1, gf2)) # if gf doesn't have taxon, check that names match
+        return name(gf1) == name(gf2)
+    elseif !all(hastaxon, (gf1, gf2)) # if one gf has taxon and other doesn't, return false
+        return false
+    else # if both have taxa, check that names of gf and taxa match
+        return name(gf1) == name(gf2) && taxon(gf1) == taxon(gf2)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,6 +189,7 @@ end
         @test filter(hastaxon, strat)         |> nfeatures == 2
         @test filter(!hastaxon, strat)        |> nfeatures == 2
         @test strat["gene1", :]               |> nfeatures == 3
+        @test strat[["gene1", "gene2"], :]    |> nfeatures == 4
         @test strat[GeneFunction("gene1"), :] |> nfeatures == 1
     end
 


### PR DESCRIPTION
Previously, `GeneFunction` instances were considered equal if their names were the same, but this makes it impossible to have stratified gene function profiles. This change:

1. make it so that equality is based on both gene function name and taxon name (if it exists). A `GeneFunction` with a taxon and one without are never equal
2. adds indexing methods to gene function-based CommunityProfiles, so if you index eg `comm["gene_name", :]`, you get _all_ rows that have `gene_name`, but if you do `comm[GeneFunction("gene_name", "species_name"), :]`, you'll get that specific row